### PR TITLE
Fix a bad JSON decode on API error

### DIFF
--- a/library/manageiq_vmdb.py
+++ b/library/manageiq_vmdb.py
@@ -92,13 +92,17 @@ class ManageIQVmdb(object):
         """
         result, info = fetch_url(self._module, self.url, data, self._headers, method)
         try:
+            if info["status"] >= 400:
+                error = json.loads(info["body"])
+                self._module.fail_json(msg=error)
+
             vmdb = json.loads(result.read())
             if self._debug:
                 vmdb['debug'] = info
+
             return vmdb
-        except AttributeError:
+        except (json.decoder.JSONDecodeError, AttributeError):
             self._module.fail_json(msg=info)
-        return json.loads(result.read())
 
 
     def get(self):


### PR DESCRIPTION
@jrafanie Please review.

If an API error occurred, the code would fail to parse the response and
you'd get a JSON decode error instead of the actual error. This change
allows the real error to bubble up.

Before this change any API error left a stacktrace ending in

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After this change we can see the real underlying error, for example,
with this 404 error

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": {"error": {"kind": "not_found", "klass": "ActiveRecord::RecordNotFound", "message": "Couldn't find Service with 'id'=80"}}}
```

---

I tested this with the following playbook against a locally running API

```yaml
- name: Test VMDB
  hosts: localhost
  roles:
  - manageiq.manageiq_vmdb
  vars:
    manageiq_connection:
      url: 'http://localhost:3000'
      username: 'admin'
      password: 'smartvm'
      manageiq_validate_certs: false
      force_basic_auth: true
  tasks:
  - name: Get a vmdb object
    manageiq_vmdb:
      href: "services/80" # Random object that doesn't exist
      #href: "" # api endpoint
    register: vmdb_object
  - name: Print the vmdb_object
    ansible.builtin.debug:
      msg: "{{ vmdb_object }}"
```

and changing the href I could see different types of errors.  I've tested this with good endpoints, 404 endpoints, unauthorized 401 endpoints, and when the body returns invalid json such as blank or raw strings.